### PR TITLE
Fix left/right key movement to move by column

### DIFF
--- a/EventListeners.js
+++ b/EventListeners.js
@@ -1,4 +1,4 @@
-import { GAME_MODE, EL_IDS } from './constants.js'
+import { EL_IDS, GAME_MODE } from './constants.js'
 import * as mutatorFns from './stateMutators.js'
 import { pxToPercent } from './utils.js'
 
@@ -32,18 +32,12 @@ export function setupEventListener(logic) {
         }
 
         // Listen for when enter is pressed to begin game
-        if (
-            GAME_MODE.INIT === logic.state.gameMode &&
-            e.key === 'Enter'
-        ) {
+        if (GAME_MODE.INIT === logic.state.gameMode && e.key === 'Enter') {
             logic.mutate(mutatorFns.startGame)
         }
-        
+
         // Listen for when enter is pressed when game is paused, to resume game
-        if (
-            GAME_MODE.PAUSED === logic.state.gameMode &&
-            e.key === 'Enter'
-        ) {
+        if (GAME_MODE.PAUSED === logic.state.gameMode && e.key === 'Enter') {
             logic.mutate(mutatorFns.setGameMode, GAME_MODE.RUNNING)
         }
 
@@ -53,7 +47,7 @@ export function setupEventListener(logic) {
         }
     })
 
-    // Fix this 
+    // Fix this
     // listen for when restart is clicked
     const restartBtn = document.getElementById(EL_IDS.restartBtn)
     restartBtn.addEventListener('click', () => {

--- a/constants.js
+++ b/constants.js
@@ -42,6 +42,8 @@ export const INIT_STATE = {
         width: 100,
         height: 20,
     },
+    playAreaWidth: 0,
+    columnsXPos: [],
     score: 0,
     gameLevel: 1,
     livesRemaining: 3,

--- a/constants.js
+++ b/constants.js
@@ -30,14 +30,14 @@ export const EL_IDS = {
     restartBtn: 'restart-btn',
     pauseBtn: 'pause-btn',
     muteBtn: 'mute-btn',
-    bgMusic: 'background-audio'
+    bgMusic: 'background-audio',
 }
 
 export const INIT_STATE = {
     basket: {
         basketValue: 0,
         xPosPx: 0,
-        xPos: 50,
+        xPos: 0,
         yPos: 0,
         width: 100,
         height: 20,
@@ -61,3 +61,5 @@ export const FALLING_OBJ_INIT_STATE = {
     denominator: 1,
     value: 0,
 }
+
+export const PLAY_COLUMNS = 8

--- a/dom.js
+++ b/dom.js
@@ -1,10 +1,21 @@
 import { EL_IDS } from './constants.js'
 import * as mutatorFns from './stateMutators.js'
+import { pxToPercent } from './utils.js'
 
 export function setupInitialDOMRelatedState(logic) {
     const basketEl = document.getElementById(EL_IDS.basket)
+    const playArea = document.getElementById(EL_IDS.playArea)
+    const columns = Array.from(
+        document.getElementById(EL_IDS.fallingObjectsList).children || [],
+    )
 
+    const columnsXPos = columns.map((el) =>
+        pxToPercent(el.offsetLeft + el.clientWidth / 2, playArea.clientWidth),
+    )
+
+    logic.mutate(mutatorFns.setColumnsXPos, columnsXPos)
     const { x, y, width, height } = basketEl.getBoundingClientRect()
+    logic.mutate(mutatorFns.setPlayAreaWidth, playArea.clientWidth)
     logic.mutate(mutatorFns.updateBasket, { xPos: x, yPos: y, width, height })
 }
 

--- a/falling.js
+++ b/falling.js
@@ -3,14 +3,14 @@
 import { percentToPx } from './utils.js'
 import { isColliding } from './collisionAlgo.js'
 import * as mutatorFns from './stateMutators.js'
-import { EL_IDS, FALLING_OBJ_INIT_STATE } from './constants.js'
+import { EL_IDS, FALLING_OBJ_INIT_STATE, PLAY_COLUMNS } from './constants.js'
 
 const DEFAULT_SPEED = 200
 const DEFAULT_RATE = 120
 
 // random from 0 to 7
 function randomColumnIndex() {
-    return Math.floor(Math.random() * 8)
+    return Math.floor(Math.random() * PLAY_COLUMNS)
 }
 
 // generate random number

--- a/rendering.js
+++ b/rendering.js
@@ -1,6 +1,6 @@
 import { EL_IDS, GAME_MODE, IMG } from './constants.js'
-import { pxToPercent } from './utils.js'
 import { playBackgroundMusic } from './dom.js'
+import { pxToPercent } from './utils.js'
 
 const toPx = (value) => `${value}px`
 const toPercent = (value) => `${value}%`
@@ -76,17 +76,17 @@ function renderBasket({ basket }) {
     const playArea = document.getElementById(EL_IDS.playArea)
 
     // Basket width in % of play area
-    const basketWidthPerc =
-        pxToPercent(basket.width, playArea.clientWidth - basket.width) / 2
+    const basketHalfWidthPerc =
+        pxToPercent(basket.width, playArea.clientWidth) / 2
 
     // Gets the left offset the basket in % of play are
-    let leftOffSetPercent = basket.xPos + basketWidthPerc / 2 + 0.3 // The 0.3% offset is for styling purposes
+    let leftOffSetPercent = basket.xPos - basketHalfWidthPerc // xPos is the center of the basket in percentage
 
     // Don't allow rendering outside of visible play area
     if (leftOffSetPercent < 0) {
         leftOffSetPercent = 0
-    } else if (leftOffSetPercent >= 100 - basketWidthPerc) {
-        leftOffSetPercent = 100 - basketWidthPerc
+    } else if (leftOffSetPercent >= 100 - basketHalfWidthPerc * 2) {
+        leftOffSetPercent = 100 - basketHalfWidthPerc * 2
     }
 
     basketDiv.style.left = toPercent(leftOffSetPercent) // setting the xPos to a percentage

--- a/rendering.js
+++ b/rendering.js
@@ -75,15 +75,18 @@ function renderBasket({ basket }) {
     const basketDiv = document.getElementById(EL_IDS.basket)
     const playArea = document.getElementById(EL_IDS.playArea)
 
-    // Basket width in % value
-    let halfOfBasket = pxToPercent(basket.width, playArea.clientWidth) / 2
+    // Basket width in % of play area
+    const basketWidthPerc =
+        pxToPercent(basket.width, playArea.clientWidth - basket.width) / 2
 
-    // Gets the of the basket in % value
-    let leftOffSetPercent = basket.xPos
+    // Gets the left offset the basket in % of play are
+    let leftOffSetPercent = basket.xPos + basketWidthPerc / 2 + 0.3 // The 0.3% offset is for styling purposes
+
+    // Don't allow rendering outside of visible play area
     if (leftOffSetPercent < 0) {
         leftOffSetPercent = 0
-    } else if (leftOffSetPercent >= 100 - halfOfBasket * 2) {
-        leftOffSetPercent = 100 - halfOfBasket * 2
+    } else if (leftOffSetPercent >= 100 - basketWidthPerc) {
+        leftOffSetPercent = 100 - basketWidthPerc
     }
 
     basketDiv.style.left = toPercent(leftOffSetPercent) // setting the xPos to a percentage

--- a/stateMutators.js
+++ b/stateMutators.js
@@ -1,15 +1,20 @@
-import { FALLING_OBJ_INIT_STATE, GAME_MODE, INIT_STATE } from './constants.js'
+import {
+    FALLING_OBJ_INIT_STATE,
+    GAME_MODE,
+    INIT_STATE,
+    PLAY_COLUMNS,
+} from './constants.js'
+import { getClosestColumn, to2DecimalPlaces } from './utils.js'
 
-function to2DecimalPlaces(num) {
-    return Math.round((num + Number.EPSILON) * 100) / 100
-}
+const columnWidthPerc = 100 / PLAY_COLUMNS
+const basketXPosMax = columnWidthPerc * (PLAY_COLUMNS - 1) // Max should be the second last column, as 0 is the first
 
 export const updateBasket = (state, { ...props }) => {
     let xPos = props.xPos
     if (xPos <= 0) {
         xPos = 0
-    } else if (xPos >= 99) {
-        xPos = 99
+    } else if (xPos >= basketXPosMax) {
+        xPos = basketXPosMax
     }
     return {
         ...state,
@@ -22,11 +27,13 @@ export const updateBasket = (state, { ...props }) => {
 }
 
 export const moveBasketLeft = (state) => {
-    let xPos = state.basket.xPos - 100 / 8
+    let xPos = getClosestColumn(state.basket.xPos - columnWidthPerc, {
+        goingLeft: true,
+        columnCount: PLAY_COLUMNS,
+    })
     if (xPos < 0) {
         xPos = 0
     }
-
     return {
         ...state,
         basket: {
@@ -37,11 +44,13 @@ export const moveBasketLeft = (state) => {
 }
 
 export const moveBasketRight = (state) => {
-    let xPos = state.basket.xPos + 100 / 8
-    if (xPos > 99) {
-        xPos = 99
+    let xPos = getClosestColumn(state.basket.xPos + columnWidthPerc, {
+        goingLeft: false,
+        columnCount: PLAY_COLUMNS,
+    })
+    if (xPos >= basketXPosMax) {
+        xPos = basketXPosMax
     }
-
     return {
         ...state,
         basket: {

--- a/stateMutators.js
+++ b/stateMutators.js
@@ -1,16 +1,22 @@
-import {
-    FALLING_OBJ_INIT_STATE,
-    GAME_MODE,
-    INIT_STATE,
-    PLAY_COLUMNS,
-} from './constants.js'
-import { getClosestColumn, to2DecimalPlaces } from './utils.js'
+import { FALLING_OBJ_INIT_STATE, GAME_MODE, INIT_STATE } from './constants.js'
+import { pxToPercent, to2DecimalPlaces } from './utils.js'
 
-const columnWidthPerc = 100 / PLAY_COLUMNS
-const basketXPosMax = columnWidthPerc * (PLAY_COLUMNS - 1) // Max should be the second last column, as 0 is the first
-
+export const setPlayAreaWidth = (state, width) => {
+    return {
+        ...state,
+        playAreaWidth: width,
+    }
+}
+export const setColumnsXPos = (state, columnsXPos) => {
+    return {
+        ...state,
+        columnsXPos,
+    }
+}
 export const updateBasket = (state, { ...props }) => {
     let xPos = props.xPos
+    let basketXPosMax =
+        100 - pxToPercent(state.basket.width, state.playAreaWidth) / 2 // xPos is the center of the basket
     if (xPos <= 0) {
         xPos = 0
     } else if (xPos >= basketXPosMax) {
@@ -27,10 +33,11 @@ export const updateBasket = (state, { ...props }) => {
 }
 
 export const moveBasketLeft = (state) => {
-    let xPos = getClosestColumn(state.basket.xPos - columnWidthPerc, {
-        goingLeft: true,
-        columnCount: PLAY_COLUMNS,
-    })
+    let xPos =
+        state.columnsXPos
+            .slice()
+            .reverse()
+            .find((x) => x < state.basket.xPos) || 0
     if (xPos < 0) {
         xPos = 0
     }
@@ -44,13 +51,9 @@ export const moveBasketLeft = (state) => {
 }
 
 export const moveBasketRight = (state) => {
-    let xPos = getClosestColumn(state.basket.xPos + columnWidthPerc, {
-        goingLeft: false,
-        columnCount: PLAY_COLUMNS,
-    })
-    if (xPos >= basketXPosMax) {
-        xPos = basketXPosMax
-    }
+    let xPos =
+        state.columnsXPos.find((x) => x > state.basket.xPos) ||
+        state.columnsXPos[state.columnsXPos.length - 1]
     return {
         ...state,
         basket: {

--- a/statefulLogic.js
+++ b/statefulLogic.js
@@ -7,6 +7,7 @@ export class StatefulLogic {
         this.getInitState = dependencies.getInitState
         this.onStateUpdate = dependencies.onStateUpdate
         this.resetState()
+        window.stateLogic = this // for debugging puroses
     }
 
     resetState() {

--- a/utils.js
+++ b/utils.js
@@ -2,3 +2,25 @@ export const pxToPercent = (px, parentWidth) => (px / parentWidth) * 100
 
 export const percentToPx = (percent, parentWidth) =>
     (percent / 100) * parentWidth
+
+export function to2DecimalPlaces(num) {
+    return Math.round((num + Number.EPSILON) * 100) / 100
+}
+
+export function getClosestColumn(
+    percentValue,
+    { columnCount, goingLeft = false },
+) {
+    let percPoints = []
+    for (let i = 0; i < columnCount; i++) {
+        const index = goingLeft ? i : columnCount - i
+        percPoints[index] = (100 / columnCount) * i
+    }
+
+    return percPoints.reduce((prev, curr) => {
+        const currDiff = Math.abs(curr - percentValue)
+        const prevDiff = Math.abs(prev - percentValue)
+
+        return currDiff <= prevDiff ? curr : prev
+    })
+}


### PR DESCRIPTION
- The resulting xPos from left/right key movements should now always place the basket in the center of a column.
- if mouse movement moves basket outside of a column, the next left/right key movement should move it to the nearest column.
- Fixes #50 