### PR TITLE
Rendering perf improvements + game over bug fix

### DIFF
--- a/falling.js
+++ b/falling.js
@@ -192,6 +192,7 @@ export function rain(logic) {
             }
         },
         restart: () => {
+            clearTimeout(timeoutId)
             fallingLogics.forEach((obj) => {
                 obj.stop()
             })
@@ -200,6 +201,7 @@ export function rain(logic) {
             run()
         },
         stop: () => {
+            clearTimeout(timeoutId)
             fallingLogics.forEach((obj) => {
                 obj.stop()
             })

--- a/index.html
+++ b/index.html
@@ -83,7 +83,10 @@
         </div>
         <div id="game-overlay" class="overlay">
             <div class="overlay-content">
-                <span id="overlay-text-start" class="overlay-text">
+                <span
+                    id="overlay-text-start"
+                    class="overlay-text overlay-text-initial"
+                >
                     Press Enter to start the game
                 </span>
                 <span id="overlay-text-pause" class="overlay-text">

--- a/main.js
+++ b/main.js
@@ -61,7 +61,7 @@ function runGame() {
                     resetRocket()
                 }, 1200)
             }
-            renderGame(state)
+            renderGame(prevState, state)
         },
         getInitState: () => ({ ...INIT_STATE }),
     })

--- a/rendering.js
+++ b/rendering.js
@@ -18,6 +18,8 @@ export function renderGame(prevState, state) {
 
     renderFallingObjects(state)
 
+    // s is the next state in this local scope
+
     if (hasStateChanged([(s) => s.livesRemaining])) {
         renderLivesRemaining(state)
     }

--- a/rendering.js
+++ b/rendering.js
@@ -6,16 +6,49 @@ const toPx = (value) => `${value}px`
 const toPercent = (value) => `${value}%`
 
 // __This is the main render function which delegates control to the more-specific render functions.__
-export function renderGame(state) {
+export function renderGame(prevState, state) {
+    function hasStateChanged(stateSelectors) {
+        for (const selector of stateSelectors) {
+            if (selector(prevState) !== selector(state)) {
+                return true
+            }
+        }
+        return false
+    }
+
     renderFallingObjects(state)
-    renderLivesRemaining(state)
-    renderBasketValue(state)
-    renderOverlay(state)
-    renderButtons(state)
-    renderBasket(state)
-    renderScore(state)
-    renderLevel(state)
-    renderSounds(state)
+
+    if (hasStateChanged([(s) => s.livesRemaining])) {
+        renderLivesRemaining(state)
+    }
+
+    if (hasStateChanged([(s) => s.basket.basketValue, (s) => s.levelTarget])) {
+        renderBasketValue(state)
+    }
+
+    if (hasStateChanged([(s) => s.gameMode])) {
+        renderOverlay(state)
+    }
+
+    if (hasStateChanged([(s) => s.gameMode, (s) => s.playSounds])) {
+        renderButtons(state)
+    }
+
+    if (hasStateChanged([(s) => s.basket.xPos])) {
+        renderBasket(state)
+    }
+
+    if (hasStateChanged([(s) => s.score])) {
+        renderScore(state)
+    }
+
+    if (hasStateChanged([(s) => s.gameLevel])) {
+        renderLevel(state)
+    }
+
+    if (hasStateChanged([(s) => s.gameMode, (s) => s.playSounds])) {
+        renderSounds(state)
+    }
 }
 
 function renderOverlay(state) {

--- a/stylesheet/main.css
+++ b/stylesheet/main.css
@@ -243,7 +243,7 @@ button:hover:disabled {
 }
 
 .overlay {
-    display: none;
+    display: block;
     position: fixed;
     top: 0;
     left: 0;
@@ -253,9 +253,15 @@ button:hover:disabled {
     background-color: rgba(0, 0, 0, 0.5);
     z-index: 1;
 }
+
 .overlay-text {
     display: none;
 }
+
+.overlay-text-initial {
+    display: block;
+}
+
 .overlay-content {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
- adds some theoretical performance improvements to the rendering logic, only actually performing DOM operations if the relevant state has changed
- also fixed a regression I introduced with the change in falling logic implementation, missing `clearTimeout` calls on game reset and stop (it meant the objs continued to spawn after game over)