### PR TITLE
Fix frozen FO from previous fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,7 +25,6 @@ function runGame() {
                         break
                     case GAME_MODE.PAUSED:
                     case GAME_MODE.INIT:
-                        rainLogic.stop()
                         rainLogic.start()
                         break
                     default:
@@ -40,6 +39,10 @@ function runGame() {
                         break
                     case GAME_MODE.RUNNING:
                         restartOrResumeRain()
+                        break
+                    case GAME_MODE.INIT: // restart
+                        rainLogic.stop()
+                        resetRocket()
                         break
                     case GAME_MODE.GAME_OVER:
                         rainLogic.stop()

--- a/stateMutators.js
+++ b/stateMutators.js
@@ -2,10 +2,10 @@ import {
     EL_IDS,
     FALLING_OBJ_INIT_STATE,
     GAME_MODE,
-    MAX_LIVES,
     INIT_STATE,
-    LEVEL_VARS,
     LEVEL_MIN_SCORES,
+    LEVEL_VARS,
+    MAX_LIVES,
 } from './constants.js'
 import { playSoundEffect } from './dom.js'
 import {
@@ -353,7 +353,7 @@ export const restartGame = (state) => {
     nextState = resetGameLevel(nextState)
     nextState = resetLevelTarget(nextState)
     nextState = resetLivesRemaining(nextState)
-    nextState = setGameMode(nextState, GAME_MODE.RUNNING)
+    nextState = setGameMode(nextState, GAME_MODE.INIT)
     return resetFallingObjects(nextState)
 }
 


### PR DESCRIPTION
So now when you click `restart` the game mode becomes `INIT` instead of `RUNNING`. Player will have to hit `Enter` or `Play` to replay the game. That way you can distinguish between game over and restart state in the scope of the `main.js` function

The naming is now off, but we can fine-tune it later